### PR TITLE
[01] Drum kit lesson

### DIFF
--- a/01 - JavaScript Drum Kit/index-START.html
+++ b/01 - JavaScript Drum Kit/index-START.html
@@ -9,56 +9,77 @@
 
 
   <div class="keys">
-    <div data-key="65" class="key">
+    <div data-key="A" class="key">
       <kbd>A</kbd>
       <span class="sound">clap</span>
     </div>
-    <div data-key="83" class="key">
+    <div data-key="S" class="key">
       <kbd>S</kbd>
       <span class="sound">hihat</span>
     </div>
-    <div data-key="68" class="key">
+    <div data-key="D" class="key">
       <kbd>D</kbd>
       <span class="sound">kick</span>
     </div>
-    <div data-key="70" class="key">
+    <div data-key="F" class="key">
       <kbd>F</kbd>
       <span class="sound">openhat</span>
     </div>
-    <div data-key="71" class="key">
+    <div data-key="G" class="key">
       <kbd>G</kbd>
       <span class="sound">boom</span>
     </div>
-    <div data-key="72" class="key">
+    <div data-key="H" class="key">
       <kbd>H</kbd>
       <span class="sound">ride</span>
     </div>
-    <div data-key="74" class="key">
+    <div data-key="J" class="key">
       <kbd>J</kbd>
       <span class="sound">snare</span>
     </div>
-    <div data-key="75" class="key">
+    <div data-key="K" class="key">
       <kbd>K</kbd>
       <span class="sound">tom</span>
     </div>
-    <div data-key="76" class="key">
+    <div data-key="L" class="key">
       <kbd>L</kbd>
       <span class="sound">tink</span>
     </div>
   </div>
 
-  <audio data-key="65" src="sounds/clap.wav"></audio>
-  <audio data-key="83" src="sounds/hihat.wav"></audio>
-  <audio data-key="68" src="sounds/kick.wav"></audio>
-  <audio data-key="70" src="sounds/openhat.wav"></audio>
-  <audio data-key="71" src="sounds/boom.wav"></audio>
-  <audio data-key="72" src="sounds/ride.wav"></audio>
-  <audio data-key="74" src="sounds/snare.wav"></audio>
-  <audio data-key="75" src="sounds/tom.wav"></audio>
-  <audio data-key="76" src="sounds/tink.wav"></audio>
+  <audio data-key="A" src="sounds/clap.wav"></audio>
+  <audio data-key="S" src="sounds/hihat.wav"></audio>
+  <audio data-key="D" src="sounds/kick.wav"></audio>
+  <audio data-key="F" src="sounds/openhat.wav"></audio>
+  <audio data-key="G" src="sounds/boom.wav"></audio>
+  <audio data-key="H" src="sounds/ride.wav"></audio>
+  <audio data-key="J" src="sounds/snare.wav"></audio>
+  <audio data-key="K" src="sounds/tom.wav"></audio>
+  <audio data-key="L" src="sounds/tink.wav"></audio>
 
 <script>
 
+  function playSound(key) {
+    const audio = document.querySelector(`audio[data-key=${key.toUpperCase()}]`)
+    const keyElem = document.querySelector(`.key[data-key=${key.toUpperCase()}]`)
+
+    if (audio) {
+      audio.currentTime = 0
+      audio.play()
+      keyElem.classList.add("playing")
+    }
+  }
+
+  function removeTransition(event) {
+    if (event.propertyName == "transform") {
+      this.classList.remove("playing")
+    }
+  }
+
+  const keys = document.querySelectorAll(".key")
+  keys.forEach(key => key.addEventListener("transitionend", removeTransition))
+
+  window.addEventListener("keydown", (e) => playSound(e.key))
 </script>
 
 


### PR DESCRIPTION
At least in current versions of chrome (69) and firefox (62), the keydown event
has a `key` property, so there's no real reason here to use the keycodes.